### PR TITLE
Use failed status when build has failed, but the pipeline is ok

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -107,11 +107,16 @@ func (p *Plugin) Exec() error {
 		panic(errors.New(fmt.Sprintf("Type must be either %s or %s", TYPE_STREAM, TYPE_PRIVATE)))
 	}
 
-	if p.Stage.Status == "" {
+	if p.Stage.Status == "failure" || p.Build.Status == "failure" {
+		notification.Status = "failure"
+	} else if p.Stage.Status != "" {
+		notification.Status = p.Stage.Status
+	} else if p.Build.Status != "" {
 		notification.Status = p.Build.Status
 	} else {
-		notification.Status = p.Stage.Status
+		notification.Status = "unknown"
 	}
+
 	if notification.Status == "success" {
 		notification.Emoji = ":check:"
 	} else {


### PR DESCRIPTION
Currently, if the build has failed, but the current pipeline is ok, the zulip notification will read "success".

This can happen, when we have pipelines, which will fail, but separate pipeline for zulip notifications (a single notification from the whole build). This pipeline is run even when the build is failed (`when` condition).

This code should be ok, as we always default to old logic, i.e., to pipeline status. Hence, if Drone changes status from `failure` to `fail` for example, this code would revert back to default.

Maybe a better solution would look this from the point of view of `success`. So, if either of the variables is something else than `success`, then the notification would become that.